### PR TITLE
Change to relative imports

### DIFF
--- a/smappy/__init__.py
+++ b/smappy/__init__.py
@@ -1,1 +1,1 @@
-from smappy.smappy import Smappee, SimpleSmappee, LocalSmappee, __version__
+from .smappy import Smappee, SimpleSmappee, LocalSmappee, __version__


### PR DESCRIPTION
Change to relative imports as local import of the module will otherwise fail (ie when not installed using setup).